### PR TITLE
Add the process ID to the /tmp/aplus paths

### DIFF
--- a/rootfs/srv/docker-compose-run.sh
+++ b/rootfs/srv/docker-compose-run.sh
@@ -17,8 +17,12 @@ exercise_path=${exercise_path%/}
 
 # Manage for docker-compose setup, see test course for reference.
 # Docker cannot bind volume from inside docker so global /tmp is used.
+# The temporary exercise mount uses the submission ID to create unique directories
+# in case multiple exercise graders are started at the same time.
+# Removing and creating the same directory simultaneously in different processes
+# obviously does not work.
 TMP=/tmp/aplus
-TMP_EXERCISE_MOUNT=$TMP/_ex/$exercise_path
+TMP_EXERCISE_MOUNT=$TMP/_ex/$SID/$exercise_path
 TMP_SUBMISSION_MOUNT=$TMP/${SUBMISSION_MOUNT#/local/grader/uploads/}
 rm -rf $TMP_EXERCISE_MOUNT
 mkdir -p $TMP_EXERCISE_MOUNT
@@ -32,7 +36,7 @@ PERSONALIZED_MOUNT=$(echo "$EXERCISE_JSON" | jq -cr '.personalized_exercise // "
 # normal exercises do not use the personalized mount
 PERSONALIZED_ARG=''
 if [ -n "$PERSONALIZED_MOUNT" ]; then
-  TMP_PERSONALIZED_MOUNT=$TMP/_personalized/${PERSONALIZED_MOUNT##$GRADER_PERSONALIZED_CONTENT_PATH}
+  TMP_PERSONALIZED_MOUNT=$TMP/_personalized/$SID/${PERSONALIZED_MOUNT#/local/grader/ex-meta/}
   rm -rf $TMP_PERSONALIZED_MOUNT
   mkdir -p $TMP_PERSONALIZED_MOUNT
   cp -r $PERSONALIZED_MOUNT $(dirname $TMP_PERSONALIZED_MOUNT)


### PR DESCRIPTION
When grading containers are started, add the process ID to the /tmp/aplus paths so that they differ for simultaneously started exercise graders. Otherwise, removing the directory under /tmp/aplus in one process breaks the other process that is trying to copy files into the directory. Several grading processes may be started simultaneously from one submission particularly in certain types of active elements.

Additionally, since the container does not read Django settings from environment variables anymore, the value `$GRADER_PERSONALIZED_CONTENT_PATH` is replaced with the correct hardcoded value (the same thing has been done previously on the `$SUBMISSION_MOUNT` line).