### PR TITLE
Add support for multiarch container images (amd64/arm64)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM apluslms/service-base:django-1.17
+FROM --platform=$TARGETPLATFORM apluslms/service-base:django-1.18
 
 COPY rootfs /
 
@@ -9,6 +9,7 @@ ENV CONTAINER_TYPE="grader" \
     GRADER_AJAX_KEY_FILE="/local/grader/ajax_key.py" \
     grader_NO_DATABASE="true"
 
+ARG TARGETPLATFORM
 ARG BRANCH=v1.19.0
 RUN : \
  && apt_install \
@@ -17,9 +18,11 @@ RUN : \
       # temp
       gnupg curl \
       libmagic1 \
+\
   # install docker-ce
+ && if [ "$TARGETPLATFORM" = "linux/amd64" ] ; then ARCH=amd64 ; elif [ "$TARGETPLATFORM" = "linux/arm64" ] ; then ARCH=arm64 ; else exit 1 ; fi \
  && curl -LSs https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg >/dev/null 2>&1 \
- && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian bullseye stable" > /etc/apt/sources.list.d/docker.list \
+ && echo "deb [arch=$ARCH signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian bullseye stable" > /etc/apt/sources.list.d/docker.list \
  && apt_install docker-ce \
 \
   # create user

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+docker run --privileged --rm tonistiigi/binfmt --install all
+
+docker buildx create --use default
+
+docker buildx build \
+--push \
+--tag "$DOCKER_REPO":"$DOCKER_TAG" \
+--platform linux/amd64,linux/arm64 .

--- a/hooks/push
+++ b/hooks/push
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+# This hook is empty because the image was pushed to the registry in the build hook

--- a/rootfs/srv/cors.patch
+++ b/rootfs/srv/cors.patch
@@ -28,11 +28,11 @@ index 9cfc947..eaab224 100644
      (
          'django.template.loaders.filesystem.Loader',
 diff --git a/requirements.txt b/requirements.txt
-index 3dbf350..9b3b5c9 100644
+index 4243873..5886328 100644
 --- a/requirements.txt
 +++ b/requirements.txt
 @@ -6,3 +6,4 @@ docutils ~= 0.17.1
  python-magic ~= 0.4.27
  aplus-auth ~= 0.2.2
- docker ~= 5.0.3
+ docker ~= 6.1.3
 +django-cors-headers ~= 3.13.0


### PR DESCRIPTION
# Description

**What?**

Add support for automatic building of multi-architecture container images (amd64/arm64).

The ``docker`` PyPI package version was updated to fix an issue with breaking changes in urllib3.
Updating the package also seems to have fixed the problem where ``/var/run/docker.sock`` ownership caused a ``PermissionError`` when running the grader on ARM-based M1 Macs. 

This PR requires that service-base has multi-architecture support first.

**Why?**

Container images built with support for the ARM architecture perform much better on Apple Silicon laptops.

**How?**

A custom build hook is used to build the image for amd64 and arm64.
The image is pushed to Docker Hub in the build hook.

Links about the docker buildx plugin for future reference:
- https://github.com/docker/buildx
- https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/
- https://hub.docker.com/r/tonistiigi/binfmt

# Testing

I tested that Docker Hub Automated Builds work as expected and that the new arm64 image works well on MacOS with the new docker Python package version.