### PR TITLE
Remove grader-init.sh

### DIFF
--- a/rootfs/srv/grader-init.sh
+++ b/rootfs/srv/grader-init.sh
@@ -1,4 +1,0 @@
-#!/bin/sh -eu
-
-# generate instances for personalized exercises (course key default)
-setuidgid $USER python3 manage.py pregenerate_exercises --gen-if-none-exist default || true


### PR DESCRIPTION
# Description

**What?**

Personalized exercise instances are now generated by course staff using a script. They should not be automatically generated each time the container is started.

Part of apluslms/mooc-grader#138